### PR TITLE
Add CancellationToken support to endpoints and refactor enums

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -110,6 +110,9 @@ dotnet_diagnostic.S6966.severity = error
 # type must match file name
 dotnet_diagnostic.MA0048.severity = none
 
+# Trailing comma in multi-line initializers
+dotnet_diagnostic.MA0007.severity = none
+
 # Types: use var
 csharp_style_var_for_built_in_types = true:error
 csharp_style_var_when_type_is_apparent = false:none

--- a/src/MentorSync.SharedKernel/Constants.cs
+++ b/src/MentorSync.SharedKernel/Constants.cs
@@ -83,7 +83,7 @@ public static class ContainerNames
 
 public static class ProgrammingLanguages
 {
-	public static List<string> Values { get; } = [
+	public static IReadOnlyList<string> Values { get; } = [
 		"JavaScript",
 		"TypeScript",
 		"Python",

--- a/src/MentorSync.SharedKernel/Extensions/EnumFormatter.cs
+++ b/src/MentorSync.SharedKernel/Extensions/EnumFormatter.cs
@@ -2,51 +2,43 @@
 
 namespace MentorSync.SharedKernel.Extensions;
 
-public static partial class EnumFormatter
+public static class EnumFormatter
 {
+	private static readonly (Industry, string)[] _industryMappings =
+		[
+			(Industry.WebDevelopment, "Веб розробка"),
+			(Industry.DataScience, "Наука даних"),
+			(Industry.CyberSecurity, "Кібербезпека"),
+			(Industry.CloudComputing, "Хмарні обчислення"),
+			(Industry.DevOps, "DevOps"),
+			(Industry.GameDevelopment, "Розробка ігор"),
+			(Industry.ItSupport, "IT підтримка"),
+			(Industry.ArtificialIntelligence, "Штучний інтелект"),
+			(Industry.Blockchain, "Блокчейн"),
+			(Industry.Networking, "Мережі"),
+			(Industry.UxUiDesign, "UX/UI дизайн"),
+			(Industry.EmbeddedSystems, "Вбудовані системи"),
+			(Industry.ItConsulting, "IT консалтинг"),
+			(Industry.DatabaseAdministration, "Адміністрування баз даних"),
+			(Industry.ProjectManagement, "Управління проектами"),
+			(Industry.MobileDevelopment, "Мобільна розробка"),
+			(Industry.LowCodeNoCode, "Low-code/No-code"),
+			(Industry.QualityControlAssurance, "Контроль якості/тестування"),
+			(Industry.MachineLearning, "Машинне навчання")
+		];
+
 	public static string GetCategories(this Industry industries)
 	{
+
 		var categories = new List<string>();
+		foreach (var (industry, name) in _industryMappings)
+		{
+			if ((industries & industry) == industry)
+			{
+				categories.Add(name);
+			}
+		}
 
-		if ((industries & Industry.WebDevelopment) == Industry.WebDevelopment)
-			categories.Add("Веб розробка");
-		if ((industries & Industry.DataScience) == Industry.DataScience)
-			categories.Add("Наука даних");
-		if ((industries & Industry.CyberSecurity) == Industry.CyberSecurity)
-			categories.Add("Кібербезпека");
-		if ((industries & Industry.CloudComputing) == Industry.CloudComputing)
-			categories.Add("Хмарні обчислення");
-		if ((industries & Industry.DevOps) == Industry.DevOps)
-			categories.Add("DevOps");
-		if ((industries & Industry.GameDevelopment) == Industry.GameDevelopment)
-			categories.Add("Розробка ігор");
-		if ((industries & Industry.ItSupport) == Industry.ItSupport)
-			categories.Add("IT підтримка");
-		if ((industries & Industry.ArtificialIntelligence) == Industry.ArtificialIntelligence)
-			categories.Add("Штучний інтелект");
-		if ((industries & Industry.Blockchain) == Industry.Blockchain)
-			categories.Add("Блокчейн");
-		if ((industries & Industry.Networking) == Industry.Networking)
-			categories.Add("Мережі");
-		if ((industries & Industry.UxUiDesign) == Industry.UxUiDesign)
-			categories.Add("UX/UI дизайн");
-		if ((industries & Industry.EmbeddedSystems) == Industry.EmbeddedSystems)
-			categories.Add("Вбудовані системи");
-		if ((industries & Industry.ItConsulting) == Industry.ItConsulting)
-			categories.Add("IT консалтинг");
-		if ((industries & Industry.DatabaseAdministration) == Industry.DatabaseAdministration)
-			categories.Add("Адміністрування баз даних");
-		if ((industries & Industry.ProjectManagement) == Industry.ProjectManagement)
-			categories.Add("Проєктний менеджемент");
-		if ((industries & Industry.MobileDevelopment) == Industry.MobileDevelopment)
-			categories.Add("Мобільна розробка");
-		if ((industries & Industry.LowCodeNoCode) == Industry.LowCodeNoCode)
-			categories.Add("Low/No кодування");
-		if ((industries & Industry.QualityControlAssurance) == Industry.QualityControlAssurance)
-			categories.Add("QA/QC");
-		if ((industries & Industry.MachineLearning) == Industry.MachineLearning)
-			categories.Add("Машинне навчання");
-
-		return categories.Count > 0 ? string.Join(", ", categories) : "Інше";
+		return string.Join(", ", categories);
 	}
 }

--- a/src/MentorSync.SharedKernel/Registration.cs
+++ b/src/MentorSync.SharedKernel/Registration.cs
@@ -9,7 +9,7 @@ public static class Registration
 {
 	public static void AddSharedServices(this IHostApplicationBuilder builder)
 	{
-		builder.AddAzureBlobClient("files-blobs");
+		builder.AddAzureBlobServiceClient("files-blobs");
 
 		builder.Services.AddMediator();
 

--- a/src/Modules/Materials/MentorSync.Materials/Features/AddTags/AddTagsToMaterialEndpoint.cs
+++ b/src/Modules/Materials/MentorSync.Materials/Features/AddTags/AddTagsToMaterialEndpoint.cs
@@ -16,7 +16,8 @@ public sealed class AddTagsToMaterialEndpoint : IEndpoint
 			int materialId,
 			AddTagsRequest request,
 			IMediator mediator,
-			HttpContext httpContext) =>
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 			{
 				var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 				if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var mentorId))
@@ -31,7 +32,7 @@ public sealed class AddTagsToMaterialEndpoint : IEndpoint
 					MentorId = mentorId
 				};
 
-				var result = await mediator.SendCommandAsync<AddTagsToMaterialCommand, AddTagsResponse>(command);
+				var result = await mediator.SendCommandAsync<AddTagsToMaterialCommand, AddTagsResponse>(command, cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Materials/MentorSync.Materials/Features/CreateMaterial/CreateMaterialEndpoint.cs
+++ b/src/Modules/Materials/MentorSync.Materials/Features/CreateMaterial/CreateMaterialEndpoint.cs
@@ -14,7 +14,8 @@ public sealed class CreateMaterialEndpoint : IEndpoint
 	{
 		app.MapPost("materials", async (
 			CreateMaterialRequest request,
-			IMediator sender) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
 				var command = new CreateMaterialCommand
 				{
@@ -26,7 +27,7 @@ public sealed class CreateMaterialEndpoint : IEndpoint
 					Tags = request.Tags
 				};
 
-				var result = await sender.SendCommandAsync<CreateMaterialCommand, CreateMaterialResponse>(command);
+				var result = await mediator.SendCommandAsync<CreateMaterialCommand, CreateMaterialResponse>(command, cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Materials/MentorSync.Materials/Features/GetMaterialById/GetMaterialByIdEndpoint.cs
+++ b/src/Modules/Materials/MentorSync.Materials/Features/GetMaterialById/GetMaterialByIdEndpoint.cs
@@ -13,9 +13,10 @@ public sealed class GetMaterialByIdEndpoint : IEndpoint
 	{
 		app.MapGet("materials/{id}", async (
 			int id,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
-				var result = await mediator.SendQueryAsync<GetMaterialByIdQuery, MaterialResponse>(new GetMaterialByIdQuery(id));
+				var result = await mediator.SendQueryAsync<GetMaterialByIdQuery, MaterialResponse>(new (id), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Materials/MentorSync.Materials/Features/GetMaterials/GetMaterialsEndpoint.cs
+++ b/src/Modules/Materials/MentorSync.Materials/Features/GetMaterials/GetMaterialsEndpoint.cs
@@ -19,9 +19,9 @@ public sealed class GetMaterialsEndpoint : IEndpoint
 			string sortBy,
 			int pageNumber,
 			int pageSize,
-			IMediator sender) =>
+			IMediator mediator) =>
 			{
-				var result = await sender.SendQueryAsync<GetMaterialsQuery, MaterialsResponse>(new GetMaterialsQuery(
+				var result = await mediator.SendQueryAsync<GetMaterialsQuery, MaterialsResponse>(new (
 					search,
 					types?.ToList(),
 					tags?.ToList(),

--- a/src/Modules/Materials/MentorSync.Materials/Features/GetMentorMaterials/GetMentorMaterialsEndpoint.cs
+++ b/src/Modules/Materials/MentorSync.Materials/Features/GetMentorMaterials/GetMentorMaterialsEndpoint.cs
@@ -12,9 +12,10 @@ public sealed class GetMentorMaterialsEndpoint : IEndpoint
 	{
 		app.MapGet("materials/mentors/{id}/materials", async (
 			int id,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
-				var result = await mediator.SendQueryAsync<GetMentorMaterialsQuery, MentorMaterialsResponse>(new GetMentorMaterialsQuery(id));
+				var result = await mediator.SendQueryAsync<GetMentorMaterialsQuery, MentorMaterialsResponse>(new (id), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Materials/MentorSync.Materials/Features/UploadMaterialAttachment/UploadMaterialAttachmentEndpoint.cs
+++ b/src/Modules/Materials/MentorSync.Materials/Features/UploadMaterialAttachment/UploadMaterialAttachmentEndpoint.cs
@@ -16,7 +16,8 @@ public sealed class UploadMaterialAttachmentEndpoint : IEndpoint
 			int materialId,
 			IFormFile file,
 			IMediator mediator,
-			HttpContext httpContext) =>
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 			{
 				var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 				if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var mentorId))
@@ -31,7 +32,7 @@ public sealed class UploadMaterialAttachmentEndpoint : IEndpoint
 					MentorId = mentorId
 				};
 
-				var result = await mediator.SendCommandAsync<UploadMaterialAttachmentCommand, UploadAttachmentResponse>(command);
+				var result = await mediator.SendCommandAsync<UploadMaterialAttachmentCommand, UploadAttachmentResponse>(command, cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Materials/MentorSync.Materials/Services/LearningMaterialsService.cs
+++ b/src/Modules/Materials/MentorSync.Materials/Services/LearningMaterialsService.cs
@@ -9,17 +9,17 @@ internal sealed class LearningMaterialsService(MaterialsDbContext dbContext) : I
 {
 	public Task<List<LearningMaterialModel>> GetAllMaterialsAsync(CancellationToken cancellationToken = default)
 	{
-		var result = dbContext.LearningMaterials
+		return dbContext.LearningMaterials
+			.AsNoTracking()
 			.Select(m => new LearningMaterialModel
 			{
 				Id = m.Id,
 				Title = m.Title,
 				Description = m.Description,
 				Type = m.Type,
-				CreatedAt = m.CreatedAt
+				CreatedAt = m.CreatedAt,
+				Tags = m.Tags.ConvertAll(t => t.Name),
 			})
 			.ToListAsync(cancellationToken);
-
-		return result;
 	}
 }

--- a/src/Modules/Notifications/MentorSync.Notifications/Domain/ChatMessage.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Domain/ChatMessage.cs
@@ -28,7 +28,7 @@ public sealed class ChatMessage
 
 	/// <summary>
 	/// Timestamp of when the message was created
-	/// </summary> 
+	/// </summary>
 	[BsonElement("CreatedAt")]
 	[BsonRepresentation(BsonType.DateTime)]
 	public DateTime CreatedAt { get; set; }

--- a/src/Modules/Notifications/MentorSync.Notifications/Features/GetAllMessages/GetAllMessagesEndpoint.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Features/GetAllMessages/GetAllMessagesEndpoint.cs
@@ -11,9 +11,9 @@ public sealed class GetAllMessagesEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapGet("notifications", async (IMediator mediator) =>
+		app.MapGet("notifications", async (IMediator mediator, CancellationToken cancellationToken) =>
 			{
-				var result = await mediator.SendQueryAsync<GetAllMessagesQuery, List<GetAllMessagesResponse>>(new GetAllMessagesQuery());
+				var result = await mediator.SendQueryAsync<GetAllMessagesQuery, List<GetAllMessagesResponse>>(new (), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatMessages/GetChatMessagesEndpoint.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatMessages/GetChatMessagesEndpoint.cs
@@ -12,7 +12,11 @@ public sealed class GetChatMessagesEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapGet("chat/messages/{roomId}", async (string roomId, IMediator mediator, HttpContext httpContext) =>
+		app.MapGet("chat/messages/{roomId}", async (
+			string roomId,
+			IMediator mediator,
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 			{
 				var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 				if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var userId))
@@ -20,7 +24,7 @@ public sealed class GetChatMessagesEndpoint : IEndpoint
 					return Results.Problem("User ID not found or invalid", statusCode: StatusCodes.Status400BadRequest);
 				}
 
-				var result = await mediator.SendQueryAsync<GetChatMessagesQuery, List<GetChatMessagesResponse>>(new GetChatMessagesQuery(roomId, userId));
+				var result = await mediator.SendQueryAsync<GetChatMessagesQuery, List<GetChatMessagesResponse>>(new (roomId, userId), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatMessages/GetChatMessagesQuery.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatMessages/GetChatMessagesQuery.cs
@@ -11,7 +11,7 @@ public sealed record GetChatMessagesQuery(string RoomId, int UserId) : IQuery<Li
 public sealed class GetChatMessagesHandler(NotificationsDbContext dbContext)
 	: IQueryHandler<GetChatMessagesQuery, List<GetChatMessagesResponse>>
 {
-	public async Task<Result<List<GetChatMessagesResponse>>> Handle(GetChatMessagesQuery request, CancellationToken cancellationToken)
+	public async Task<Result<List<GetChatMessagesResponse>>> Handle(GetChatMessagesQuery request, CancellationToken cancellationToken = default)
 	{
 		var roomObjectId = ObjectId.Parse(request.RoomId);
 		var userId = request.UserId;

--- a/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatParticipants/GetChatParticipantsEndpoint.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatParticipants/GetChatParticipantsEndpoint.cs
@@ -12,7 +12,10 @@ public sealed class GetChatParticipantsEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapGet("chat/participants", async (IMediator mediator, HttpContext context) =>
+		app.MapGet("chat/participants", async (
+			IMediator mediator,
+			HttpContext context,
+			CancellationToken cancellationToken) =>
 			{
 				var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
 				if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var userId))
@@ -20,7 +23,7 @@ public sealed class GetChatParticipantsEndpoint : IEndpoint
 					return Results.Problem("User ID not found or invalid", statusCode: StatusCodes.Status400BadRequest);
 				}
 
-				var result = await mediator.SendQueryAsync<GetChatParticipantsQuery, List<GetChatParticipantsResponse>>(new GetChatParticipantsQuery(userId));
+				var result = await mediator.SendQueryAsync<GetChatParticipantsQuery, List<GetChatParticipantsResponse>>(new (userId), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatParticipants/GetChatParticipantsQuery.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatParticipants/GetChatParticipantsQuery.cs
@@ -8,7 +8,7 @@ public sealed record GetChatParticipantsQuery(int UserId) : IQuery<List<GetChatP
 public sealed class GetChatParticipantsHandler(IUserService userService)
 	: IQueryHandler<GetChatParticipantsQuery, List<GetChatParticipantsResponse>>
 {
-	public async Task<Result<List<GetChatParticipantsResponse>>> Handle(GetChatParticipantsQuery request, CancellationToken cancellationToken)
+	public async Task<Result<List<GetChatParticipantsResponse>>> Handle(GetChatParticipantsQuery request, CancellationToken cancellationToken = default)
 	{
 		var users = await userService.GetAllUsersExceptAsync(request.UserId);
 

--- a/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatRooms/GetChatRoomsEndpoint.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatRooms/GetChatRoomsEndpoint.cs
@@ -12,7 +12,10 @@ public sealed class GetChatRoomsEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapGet("chat/rooms", async (IMediator mediator, HttpContext httpContext) =>
+		app.MapGet("chat/rooms", async (
+			IMediator mediator,
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 			{
 				var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 				if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var userId))
@@ -20,7 +23,7 @@ public sealed class GetChatRoomsEndpoint : IEndpoint
 					return Results.Problem("User ID not found or invalid", statusCode: StatusCodes.Status400BadRequest);
 				}
 
-				var result = await mediator.SendQueryAsync<GetChatRoomsQuery, List<GetChatRoomsResponse>>(new GetChatRoomsQuery(userId), httpContext.RequestAborted);
+				var result = await mediator.SendQueryAsync<GetChatRoomsQuery, List<GetChatRoomsResponse>>(new GetChatRoomsQuery(userId), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatRooms/GetChatRoomsQuery.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Features/GetChatRooms/GetChatRoomsQuery.cs
@@ -10,7 +10,7 @@ public sealed record GetChatRoomsQuery(int UserId) : IQuery<List<GetChatRoomsRes
 public sealed class GetChatRoomsHandler(NotificationsDbContext dbContext)
 	: IQueryHandler<GetChatRoomsQuery, List<GetChatRoomsResponse>>
 {
-	public async Task<Result<List<GetChatRoomsResponse>>> Handle(GetChatRoomsQuery request, CancellationToken cancellationToken)
+	public async Task<Result<List<GetChatRoomsResponse>>> Handle(GetChatRoomsQuery request, CancellationToken cancellationToken = default)
 	{
 		var userId = request.UserId;
 		var filter = Builders<ChatRoom>.Filter.Or(

--- a/src/Modules/Notifications/MentorSync.Notifications/Features/InitiateChat/InitiateChatEndpoint.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Features/InitiateChat/InitiateChatEndpoint.cs
@@ -12,7 +12,11 @@ public sealed class InitiateChatEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapPost("chat/initiate", async (InitiateChatRequest request, IMediator mediator, HttpContext httpContext) =>
+		app.MapPost("chat/initiate", async (
+			InitiateChatRequest request,
+			IMediator mediator,
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 			{
 				var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 				if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var userId))
@@ -20,7 +24,7 @@ public sealed class InitiateChatEndpoint : IEndpoint
 					return Results.Problem("User ID not found or invalid", statusCode: StatusCodes.Status400BadRequest);
 				}
 
-				var result = await mediator.SendCommandAsync<InitiateChatCommand, InitiateChatResponse>(new InitiateChatCommand(userId, request.RecipientId), httpContext.RequestAborted);
+				var result = await mediator.SendCommandAsync<InitiateChatCommand, InitiateChatResponse>(new InitiateChatCommand(userId, request.RecipientId), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Notifications/MentorSync.Notifications/Features/SendNotification/BookingStatusChangedEventHandler.cs
+++ b/src/Modules/Notifications/MentorSync.Notifications/Features/SendNotification/BookingStatusChangedEventHandler.cs
@@ -10,7 +10,7 @@ public sealed class BookingStatusChangedEventHandler(
 	IHubContext<NotificationHub> hubContext,
 	ILogger<BookingStatusChangedEventHandler> logger) : INotificationHandler<BookingStatusChangedEvent>
 {
-	public async Task HandleAsync(BookingStatusChangedEvent notification, CancellationToken cancellationToken)
+	public async Task HandleAsync(BookingStatusChangedEvent notification, CancellationToken cancellationToken = default)
 	{
 		try
 		{

--- a/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Create/CreateMaterialReviewEndpoint.cs
+++ b/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Create/CreateMaterialReviewEndpoint.cs
@@ -12,10 +12,11 @@ public sealed class CreateMaterialReviewEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapPost("ratings/materials/{materialId}/reviews", async (
+		app.MapPost("ratings/materials/{materialId:int}/reviews", async (
 			int materialId,
 			[FromBody] CreateMaterialReviewRequest request,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
 				var command = new CreateMaterialReviewCommand(
 					materialId,
@@ -23,7 +24,7 @@ public sealed class CreateMaterialReviewEndpoint : IEndpoint
 					request.Rating,
 					request.ReviewText);
 
-				var result = await mediator.SendCommandAsync<CreateMaterialReviewCommand, CreateMaterialReviewResponse>(command);
+				var result = await mediator.SendCommandAsync<CreateMaterialReviewCommand, CreateMaterialReviewResponse>(command, cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Delete/DeleteMaterialReviewEndpoint.cs
+++ b/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Delete/DeleteMaterialReviewEndpoint.cs
@@ -12,14 +12,15 @@ public sealed class DeleteMaterialReviewEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapDelete("ratings/materials/reviews/{reviewId}", async (
+		app.MapDelete("ratings/materials/reviews/{reviewId:int}", async (
 			int reviewId,
 			[FromQuery] int userId,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
 				var command = new DeleteMaterialReviewCommand(reviewId, userId);
 
-				var result = await mediator.SendCommandAsync<DeleteMaterialReviewCommand, string>(command);
+				var result = await mediator.SendCommandAsync<DeleteMaterialReviewCommand, string>(command, cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Get/GetMaterialReviewsEndpoint.cs
+++ b/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Get/GetMaterialReviewsEndpoint.cs
@@ -11,12 +11,13 @@ public sealed class GetMaterialReviewsEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapGet("ratings/materials/{id}/reviews", async (
+		app.MapGet("ratings/materials/{id:int}/reviews", async (
 			int id,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
 				var result = await mediator
-							.SendQueryAsync<GetMaterialReviewsQuery, MaterialReviewsResponse>(new GetMaterialReviewsQuery(id));
+							.SendQueryAsync<GetMaterialReviewsQuery, MaterialReviewsResponse>(new GetMaterialReviewsQuery(id), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Get/GetMaterialReviewsQueryHandler.cs
+++ b/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Get/GetMaterialReviewsQueryHandler.cs
@@ -9,7 +9,8 @@ public sealed class GetMaterialReviewsQueryHandler(
 	RatingsDbContext dbContext)
 	: IQueryHandler<GetMaterialReviewsQuery, MaterialReviewsResponse>
 {
-	public async Task<Result<MaterialReviewsResponse>> Handle(GetMaterialReviewsQuery request, CancellationToken cancellationToken)
+	public async Task<Result<MaterialReviewsResponse>> Handle(
+		GetMaterialReviewsQuery request, CancellationToken cancellationToken = default)
 	{
 		var reviews = await dbContext.Database.SqlQuery<MaterialReviewEntityDto>(
 			$"""

--- a/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/GetForUser/GetUserMaterialReviewEndpoint.cs
+++ b/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/GetForUser/GetUserMaterialReviewEndpoint.cs
@@ -11,13 +11,14 @@ public sealed class GetUserMaterialReviewEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapGet("ratings/materials/{materialId}/user/{userId}/review", async (
+		app.MapGet("ratings/materials/{materialId:int}/user/{userId:int}/review", async (
 			int materialId,
 			int userId,
-			IMediator sender) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
 				var query = new GetUserMaterialReviewQuery(materialId, userId);
-				var result = await sender.SendQueryAsync<GetUserMaterialReviewQuery, UserMaterialReviewResponse>(query);
+				var result = await mediator.SendQueryAsync<GetUserMaterialReviewQuery, UserMaterialReviewResponse>(query, cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/GetForUser/GetUserMaterialReviewQueryHandler.cs
+++ b/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/GetForUser/GetUserMaterialReviewQueryHandler.cs
@@ -8,7 +8,8 @@ public sealed class GetUserMaterialReviewQueryHandler(
 	RatingsDbContext dbContext)
 	: IQueryHandler<GetUserMaterialReviewQuery, UserMaterialReviewResponse>
 {
-	public async Task<Result<UserMaterialReviewResponse>> Handle(GetUserMaterialReviewQuery request, CancellationToken cancellationToken)
+	public async Task<Result<UserMaterialReviewResponse>> Handle(
+		GetUserMaterialReviewQuery request, CancellationToken cancellationToken = default)
 	{
 		var review = await dbContext.MaterialReviews
 				 .Where(mr => mr.MaterialId == request.MaterialId && mr.ReviewerId == request.UserId)

--- a/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Update/UpdateMaterialReviewEndpoint.cs
+++ b/src/Modules/Ratings/MentorSync.Ratings/Features/MaterialReview/Update/UpdateMaterialReviewEndpoint.cs
@@ -16,14 +16,14 @@ public sealed class UpdateMaterialReviewEndpoint : IEndpoint
 		app.MapPut("ratings/reviews/material", async (
 			IMediator mediator,
 			[FromBody] UpdateMaterialReviewCommand request,
-			CancellationToken ct) =>
+			CancellationToken cancellationToken) =>
 		{
-			var result = await mediator.SendCommandAsync<UpdateMaterialReviewCommand, string>(request, ct);
+			var result = await mediator.SendCommandAsync<UpdateMaterialReviewCommand, string>(request, cancellationToken);
 			return result.DecideWhatToReturn();
 		})
 		.WithTags(TagsConstants.Ratings)
 		.WithDescription("Updates an existing review for a material")
-		.Produces<Result>(StatusCodes.Status200OK)
+		.Produces<string>(StatusCodes.Status200OK)
 		.ProducesProblem(StatusCodes.Status400BadRequest)
 		.RequireAuthorization(PolicyConstants.ActiveUserOnly, PolicyConstants.MentorMenteeMix);
 	}

--- a/src/Modules/Ratings/MentorSync.Ratings/Features/MentorReview/Check/CheckMentorReviewQueryHandler.cs
+++ b/src/Modules/Ratings/MentorSync.Ratings/Features/MentorReview/Check/CheckMentorReviewQueryHandler.cs
@@ -10,7 +10,7 @@ public sealed class CheckMentorReviewQueryHandler(
 {
 	public async Task<Result<CheckMentorReviewResponse>> Handle(
 		CheckMentorReviewQuery query,
-		CancellationToken cancellationToken)
+		CancellationToken cancellationToken = default)
 	{
 		var existingReview = await dbContext.MentorReviews
 				.AsNoTracking()

--- a/src/Modules/Ratings/MentorSync.Ratings/Features/MentorReview/Get/GetMentorReviewsEndpoint.cs
+++ b/src/Modules/Ratings/MentorSync.Ratings/Features/MentorReview/Get/GetMentorReviewsEndpoint.cs
@@ -13,9 +13,10 @@ public sealed class GetMentorReviewsEndpoint : IEndpoint
 	{
 		app.MapGet("ratings/mentors/{id}/reviews", async (
 			int id,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
-				var result = await mediator.SendQueryAsync<GetMentorReviewsQuery, MentorReviewsResponse>(new GetMentorReviewsQuery(id));
+				var result = await mediator.SendQueryAsync<GetMentorReviewsQuery, MentorReviewsResponse>(new (id), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Recommendations/MentorSync.Recommendations/Features/CheckBookmark/CheckBookmarkEndpoint.cs
+++ b/src/Modules/Recommendations/MentorSync.Recommendations/Features/CheckBookmark/CheckBookmarkEndpoint.cs
@@ -16,7 +16,8 @@ public sealed class CheckBookmarkEndpoint : IEndpoint
 		app.MapGet("/recommendations/bookmarks/check/{mentorId:int}", async (
 			[FromRoute] int mentorId,
 			IMediator mediator,
-			HttpContext httpContext) =>
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 		{
 			var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 			if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var menteeId))
@@ -25,7 +26,7 @@ public sealed class CheckBookmarkEndpoint : IEndpoint
 			}
 
 			var query = new CheckBookmarkQuery(menteeId, mentorId);
-			var result = await mediator.SendQueryAsync<CheckBookmarkQuery, CheckBookmarkResult>(query, httpContext.RequestAborted);
+			var result = await mediator.SendQueryAsync<CheckBookmarkQuery, CheckBookmarkResult>(query, cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Recommendations/MentorSync.Recommendations/Features/CreateBookmark/CreateBookmarkEndpoint.cs
+++ b/src/Modules/Recommendations/MentorSync.Recommendations/Features/CreateBookmark/CreateBookmarkEndpoint.cs
@@ -16,7 +16,8 @@ public sealed class CreateBookmarkEndpoint : IEndpoint
 		app.MapPost("/recommendations/bookmark/{mentorId}", async (
 			[FromRoute] int mentorId,
 			IMediator mediator,
-			HttpContext httpContext) =>
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 		{
 			var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 			if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var menteeId))
@@ -24,7 +25,7 @@ public sealed class CreateBookmarkEndpoint : IEndpoint
 				return Results.Problem("User ID not found or invalid", statusCode: StatusCodes.Status400BadRequest);
 			}
 
-			var result = await mediator.SendCommandAsync<CreateBookmarkCommand, string>(new CreateBookmarkCommand(menteeId, mentorId), httpContext.RequestAborted);
+			var result = await mediator.SendCommandAsync<CreateBookmarkCommand, string>(new CreateBookmarkCommand(menteeId, mentorId), cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Recommendations/MentorSync.Recommendations/Features/CreateMentorViewEvent/CreateMentorViewEventEndpoint.cs
+++ b/src/Modules/Recommendations/MentorSync.Recommendations/Features/CreateMentorViewEvent/CreateMentorViewEventEndpoint.cs
@@ -16,7 +16,8 @@ public sealed class CreateMentorViewEventEndpoint : IEndpoint
 		app.MapPost("/recommendations/view-mentor/{mentorId}", async (
 			[FromRoute] int mentorId,
 			IMediator mediator,
-			HttpContext httpContext) =>
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 		{
 			var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 			if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var menteeId))
@@ -24,7 +25,7 @@ public sealed class CreateMentorViewEventEndpoint : IEndpoint
 				return Results.Problem("User ID not found or invalid", statusCode: StatusCodes.Status400BadRequest);
 			}
 
-			var result = await mediator.SendCommandAsync<CreateMentorViewEventCommand, string>(new(menteeId, mentorId), httpContext.RequestAborted);
+			var result = await mediator.SendCommandAsync<CreateMentorViewEventCommand, string>(new (menteeId, mentorId), cancellationToken);
 			return result.DecideWhatToReturn();
 		})
 		.WithTags(TagsConstants.Recommendations)

--- a/src/Modules/Recommendations/MentorSync.Recommendations/Features/DeleteBookmark/DeleteBookmarkEndpoint.cs
+++ b/src/Modules/Recommendations/MentorSync.Recommendations/Features/DeleteBookmark/DeleteBookmarkEndpoint.cs
@@ -16,7 +16,8 @@ public sealed class DeleteBookmarkEndpoint : IEndpoint
 		app.MapDelete("/recommendations/bookmarks/{mentorId:int}", async (
 			[FromRoute] int mentorId,
 			IMediator mediator,
-			HttpContext httpContext) =>
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 		{
 			var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 			if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var menteeId))
@@ -24,7 +25,7 @@ public sealed class DeleteBookmarkEndpoint : IEndpoint
 				return Results.Problem("User ID not found or invalid", statusCode: StatusCodes.Status400BadRequest);
 			}
 
-			var result = await mediator.SendCommandAsync<DeleteBookmarkCommand, string>(new(menteeId, mentorId), httpContext.RequestAborted);
+			var result = await mediator.SendCommandAsync<DeleteBookmarkCommand, string>(new(menteeId, mentorId), cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Recommendations/MentorSync.Recommendations/Features/GetRecommendedMaterials/GetRecommendedMaterialsEndpoint.cs
+++ b/src/Modules/Recommendations/MentorSync.Recommendations/Features/GetRecommendedMaterials/GetRecommendedMaterialsEndpoint.cs
@@ -23,7 +23,7 @@ public sealed class GetRecommendedMaterialsEndpoint : IEndpoint
 			[FromQuery] int? pageSize,
 			IMediator sender,
 			HttpContext httpContext,
-			CancellationToken ct) =>
+			CancellationToken cancellationToken) =>
 		{
 			var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 			if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var userId))
@@ -38,7 +38,7 @@ public sealed class GetRecommendedMaterialsEndpoint : IEndpoint
 					tags?.ToList() ?? [],
 					type,
 					pageNumber ?? 1,
-					pageSize ?? 10), ct);
+					pageSize ?? 10), cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Recommendations/MentorSync.Recommendations/Features/GetRecommendedMentors/GetRecommendedMentorsEndpoint.cs
+++ b/src/Modules/Recommendations/MentorSync.Recommendations/Features/GetRecommendedMentors/GetRecommendedMentorsEndpoint.cs
@@ -26,7 +26,7 @@ public sealed class GetRecommendedMentorsEndpoint : IEndpoint
 			[FromQuery] int? pageSize,
 			IMediator mediator,
 			HttpContext httpContext,
-			CancellationToken ct) =>
+			CancellationToken cancellationToken) =>
 		{
 			var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
 			if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var userId))
@@ -45,7 +45,7 @@ public sealed class GetRecommendedMentorsEndpoint : IEndpoint
 				minRating,
 				maxRating,
 				pageNumber ?? 1,
-				pageSize ?? 10), ct);
+				pageSize ?? 10), cancellationToken);
 
 			return result.DecideWhatToReturn();
 		}).WithTags(TagsConstants.Recommendations)

--- a/src/Modules/Scheduling/MentorSync.Scheduling/Features/Booking/Create/CreateBookingEndpoint.cs
+++ b/src/Modules/Scheduling/MentorSync.Scheduling/Features/Booking/Create/CreateBookingEndpoint.cs
@@ -16,7 +16,8 @@ public sealed class CreateBookingEndpoint : IEndpoint
 		app.MapPost("/scheduling/bookings", async (
 			[FromBody] CreateBookingRequest request,
 			IMediator mediator,
-			HttpContext httpContext) =>
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
 		{
 			// Get the mentee ID from the current user
 			var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
@@ -32,7 +33,7 @@ public sealed class CreateBookingEndpoint : IEndpoint
 				request.Start,
 				request.End);
 
-			var result = await mediator.SendCommandAsync<CreateBookingCommand, CreateBookingResult>(command, httpContext.RequestAborted);
+			var result = await mediator.SendCommandAsync<CreateBookingCommand, CreateBookingResult>(command, cancellationToken);
 			return result.DecideWhatToReturn();
 		})
 		.WithTags(TagsConstants.Scheduling)

--- a/src/Modules/Scheduling/MentorSync.Scheduling/Features/Booking/UpdatePending/UpdatePendingBookingsCommand.cs
+++ b/src/Modules/Scheduling/MentorSync.Scheduling/Features/Booking/UpdatePending/UpdatePendingBookingsCommand.cs
@@ -1,3 +1,3 @@
 ﻿namespace MentorSync.Scheduling.Features.Booking.UpdatePending;
 
-public sealed record UpdatePendingBookingsCommand() : ICommand<int>;
+public sealed record UpdatePendingBookingsCommand : ICommand<int>;

--- a/src/Modules/Scheduling/MentorSync.Scheduling/Features/Booking/UpdatePending/UpdatePendingBookingsCommandHandler.cs
+++ b/src/Modules/Scheduling/MentorSync.Scheduling/Features/Booking/UpdatePending/UpdatePendingBookingsCommandHandler.cs
@@ -16,8 +16,8 @@ public sealed class UpdatePendingBookingsCommandHandler(SchedulingDbContext sche
 		var updated = await schedulingDbContext.Bookings
 			.Where(b => (b.Status == BookingStatus.Pending || b.Status == BookingStatus.Confirmed) && b.Start < now)
 			.ExecuteUpdateAsync(b => b
-				.SetProperty(b => b.Status, BookingStatus.NoShow)
-				.SetProperty(b => b.UpdatedAt, now),
+				.SetProperty(booking => booking.Status, BookingStatus.NoShow)
+				.SetProperty(booking => booking.UpdatedAt, now),
 				cancellationToken);
 
 		return Result.Success(updated, $"Updated {updated} pending bookings to NoShow status.");

--- a/src/Modules/Scheduling/MentorSync.Scheduling/Features/GetMentorUpcomingSessions/GetMentorUpcomingSessionsEndpoint.cs
+++ b/src/Modules/Scheduling/MentorSync.Scheduling/Features/GetMentorUpcomingSessions/GetMentorUpcomingSessionsEndpoint.cs
@@ -10,11 +10,12 @@ public sealed class GetMentorUpcomingSessionsEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapGet("scheduling/mentors/{id}/upcoming-sessions", async (
+		app.MapGet("scheduling/mentors/{id:int}/upcoming-sessions", async (
 			int id,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
-				var result = await mediator.SendQueryAsync<GetMentorUpcomingSessionsQuery, MentorUpcomingSessionsResponse>(new(id));
+				var result = await mediator.SendQueryAsync<GetMentorUpcomingSessionsQuery, MentorUpcomingSessionsResponse>(new(id), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Scheduling/MentorSync.Scheduling/Features/MentorAvailability/Create/CreateMentorAvailabilityEndpoint.cs
+++ b/src/Modules/Scheduling/MentorSync.Scheduling/Features/MentorAvailability/Create/CreateMentorAvailabilityEndpoint.cs
@@ -15,7 +15,8 @@ public sealed class CreateMentorAvailabilityEndpoint : IEndpoint
 		app.MapPost("/scheduling/mentors/{mentorId:int}/availability", async (
 			[FromRoute] int mentorId,
 			[FromBody] CreateMentorAvailabilityRequest request,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 		{
 			var command = new CreateMentorAvailabilityCommand(
 				mentorId,
@@ -23,7 +24,7 @@ public sealed class CreateMentorAvailabilityEndpoint : IEndpoint
 				request.End);
 
 			var result = await mediator
-							   .SendCommandAsync<CreateMentorAvailabilityCommand, CreateMentorAvailabilityResult>(command);
+							   .SendCommandAsync<CreateMentorAvailabilityCommand, CreateMentorAvailabilityResult>(command, cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Scheduling/MentorSync.Scheduling/Features/MentorAvailability/Delete/DeleteMentorAvailabilityEndpoint.cs
+++ b/src/Modules/Scheduling/MentorSync.Scheduling/Features/MentorAvailability/Delete/DeleteMentorAvailabilityEndpoint.cs
@@ -15,13 +15,14 @@ public sealed class DeleteMentorAvailabilityEndpoint : IEndpoint
 		app.MapDelete("/scheduling/mentors/{mentorId:int}/availability/{availabilityId:int}", async (
 			[FromRoute] int mentorId,
 			[FromRoute] int availabilityId,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 		{
 			var command = new DeleteMentorAvailabilityCommand(
 				mentorId,
 				availabilityId);
 
-			var result = await mediator.SendCommandAsync<DeleteMentorAvailabilityCommand, string>(command);
+			var result = await mediator.SendCommandAsync<DeleteMentorAvailabilityCommand, string>(command, cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Scheduling/MentorSync.Scheduling/Features/MentorAvailability/Get/GetMentorAvailabilityEndpoint.cs
+++ b/src/Modules/Scheduling/MentorSync.Scheduling/Features/MentorAvailability/Get/GetMentorAvailabilityEndpoint.cs
@@ -16,7 +16,8 @@ public sealed class GetMentorAvailabilityEndpoint : IEndpoint
 			[FromRoute] int mentorId,
 			[FromQuery] DateTime startDate,
 			[FromQuery] DateTime endDate,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 		{
 			var start = startDate != default
 				? new DateTimeOffset(startDate)
@@ -27,7 +28,7 @@ public sealed class GetMentorAvailabilityEndpoint : IEndpoint
 				: start.AddDays(7).AddSeconds(-1);
 
 			var query = new GetMentorAvailabilityQuery(mentorId, start, end);
-			var result = await mediator.SendQueryAsync<GetMentorAvailabilityQuery, MentorAvailabilityResult>(query);
+			var result = await mediator.SendQueryAsync<GetMentorAvailabilityQuery, MentorAvailabilityResult>(query, cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Users/MentorSync.Users/Features/Confirm/ConfirmAccountEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/Confirm/ConfirmAccountEndpoint.cs
@@ -12,9 +12,13 @@ public sealed class ConfirmAccountEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapGet("/users/confirm", async ([FromQuery] string email, [FromQuery] string token, IMediator mediator) =>
+		app.MapGet("/users/confirm", async (
+				[FromQuery] string email,
+				[FromQuery] string token,
+				IMediator mediator,
+				CancellationToken cancellationToken) =>
 		{
-			var result = await mediator.SendCommandAsync<ConfirmAccountCommand, string>(new ConfirmAccountCommand(email, token));
+			var result = await mediator.SendCommandAsync<ConfirmAccountCommand, string>(new ConfirmAccountCommand(email, token), cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Users/MentorSync.Users/Features/DeleteAvatar/DeleteAvatarEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/DeleteAvatar/DeleteAvatarEndpoint.cs
@@ -13,9 +13,10 @@ public sealed class DeleteAvatarEndpoint : IEndpoint
 	{
 		app.MapDelete("/users/{id:int}/avatar", async (
 				int id,
-				IMediator mediator) =>
+				IMediator mediator,
+				CancellationToken cancellationToken) =>
 		{
-			var result = await mediator.SendCommandAsync<DeleteAvatarCommand, string>(new DeleteAvatarCommand(id));
+			var result = await mediator.SendCommandAsync<DeleteAvatarCommand, string>(new DeleteAvatarCommand(id), cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Users/MentorSync.Users/Features/GetAllUsers/GetAllUsersEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/GetAllUsers/GetAllUsersEndpoint.cs
@@ -15,10 +15,11 @@ public sealed class GetAllUsersEndpoint : IEndpoint
 		app.MapGet("users", async (
 			[FromQuery] string role,
 			[FromQuery] bool? isActive,
-			IMediator mediator)
+			IMediator mediator,
+			CancellationToken cancellationToken)
 				=>
 			{
-				var result = await mediator.SendQueryAsync<GetAllUsersQuery, List<UserShortResponse>>(new(role, isActive));
+				var result = await mediator.SendQueryAsync<GetAllUsersQuery, List<UserShortResponse>>(new(role, isActive), cancellationToken);
 				return result.DecideWhatToReturn();
 			})
 			.WithTags(TagsConstants.Users)

--- a/src/Modules/Users/MentorSync.Users/Features/GetMentorBasicInfo/GetMentorBasicInfoEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/GetMentorBasicInfo/GetMentorBasicInfoEndpoint.cs
@@ -11,11 +11,12 @@ public sealed class GetMentorBasicInfoEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapGet("users/mentors/{id}/basic-info", async (
+		app.MapGet("users/mentors/{id:int}/basic-info", async (
 			int id,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
-				var result = await mediator.SendQueryAsync<GetMentorBasicInfoQuery, MentorBasicInfoResponse>(new GetMentorBasicInfoQuery(id));
+				var result = await mediator.SendQueryAsync<GetMentorBasicInfoQuery, MentorBasicInfoResponse>(new GetMentorBasicInfoQuery(id), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})

--- a/src/Modules/Users/MentorSync.Users/Features/Login/LoginEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/Login/LoginEndpoint.cs
@@ -13,9 +13,12 @@ public sealed class LoginEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapPost("/users/login", async (LoginCommand command, IMediator mediator) =>
+		app.MapPost("/users/login", async (
+				LoginCommand command,
+				IMediator mediator,
+				CancellationToken cancellationToken) =>
 			{
-				var result = await mediator.SendCommandAsync<LoginCommand, AuthResponse>(command);
+				var result = await mediator.SendCommandAsync<LoginCommand, AuthResponse>(command, cancellationToken);
 				return result.DecideWhatToReturn();
 			})
 			.WithTags(TagsConstants.Users)

--- a/src/Modules/Users/MentorSync.Users/Features/Mentor/EditProfile/EditMentorProfileCommandHandler.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/Mentor/EditProfile/EditMentorProfileCommandHandler.cs
@@ -12,8 +12,10 @@ public class EditMentorProfileCommandHandler(UsersDbContext db)
 	public async Task<Result<MentorProfileResponse>> Handle(EditMentorProfileCommand request, CancellationToken cancellationToken = default)
 	{
 		var entity = await db.MentorProfiles.FirstOrDefaultAsync(mp => mp.Id == request.Id, cancellationToken: cancellationToken);
-		if (entity == null)
+		if (entity is null)
+		{
 			return Result.NotFound($"MentorProfile {request.Id} not found.");
+		}
 
 		entity.UpdateFrom(request);
 		await db.SaveChangesAsync(cancellationToken);

--- a/src/Modules/Users/MentorSync.Users/Features/Refresh/RefreshTokenEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/Refresh/RefreshTokenEndpoint.cs
@@ -15,9 +15,10 @@ public sealed class RefreshTokenEndpoint : IEndpoint
 	{
 		app.MapPost("/users/refresh-token", async (
 			RefreshTokenCommand command,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 		{
-			var result = await mediator.SendCommandAsync<RefreshTokenCommand, AuthResponse>(command);
+			var result = await mediator.SendCommandAsync<RefreshTokenCommand, AuthResponse>(command, cancellationToken);
 			return result.DecideWhatToReturn();
 		})
 		.WithTags(TagsConstants.Users)

--- a/src/Modules/Users/MentorSync.Users/Features/Register/RegisterEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/Register/RegisterEndpoint.cs
@@ -23,9 +23,12 @@ public sealed class RegisterEndpoint : IEndpoint
 	/// <param name="app">The endpoint route builder used to configure the API endpoint.</param>
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapPost("users/register", async (RegisterCommand request, IMediator mediator) =>
+		app.MapPost("users/register", async (
+				RegisterCommand request,
+				IMediator mediator,
+				CancellationToken cancellationToken) =>
 		{
-			var result = await mediator.SendCommandAsync<RegisterCommand, CreatedEntityResponse>(request);
+			var result = await mediator.SendCommandAsync<RegisterCommand, CreatedEntityResponse>(request, cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Users/MentorSync.Users/Features/ResendConfirmation/ResendConfirmationEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/ResendConfirmation/ResendConfirmationEndpoint.cs
@@ -15,17 +15,17 @@ public sealed class ResendConfirmationEndpoint : IEndpoint
 	{
 		app.MapGet("/users/reconfirm", async (
 			[FromQuery, Required] int userId,
-			IPublisher<UserCreatedEvent> eventPublisher) =>
-			{
-				await eventPublisher.PublishAsync(new UserCreatedEvent(userId));
+			IPublisher<UserCreatedEvent> eventPublisher,
+			CancellationToken cancellationToken) =>
+		{
+			await eventPublisher.PublishAsync(new UserCreatedEvent(userId), cancellationToken);
 
-				return Results.Ok("Confirmation email sent");
-			})
-			.WithTags(TagsConstants.Users)
-			.WithDescription("Resend confirmation email to user")
-			.AllowAnonymous()
-			.Produces<string>()
-			.Produces<ProblemDetails>(StatusCodes.Status400BadRequest)
-			.RequireAuthorization(PolicyConstants.AdminOnly);
+			return Results.Ok("Confirmation email sent");
+		})
+		.WithTags(TagsConstants.Users)
+		.WithDescription("Resend confirmation email to user")
+		.Produces<string>()
+		.Produces<ProblemDetails>(StatusCodes.Status400BadRequest)
+		.RequireAuthorization(PolicyConstants.AdminOnly);
 	}
 }

--- a/src/Modules/Users/MentorSync.Users/Features/ResetPassword/ResetPasswordEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/ResetPassword/ResetPasswordEndpoint.cs
@@ -13,9 +13,10 @@ public sealed class ResetPasswordEndpoint : IEndpoint
 	{
 		app.MapPost("/users/reset-password", async (
 			ResetPasswordCommand command,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 		{
-			var result = await mediator.SendCommandAsync<ResetPasswordCommand, string>(command);
+			var result = await mediator.SendCommandAsync<ResetPasswordCommand, string>(command, cancellationToken);
 			return result.DecideWhatToReturn();
 		})
 		.WithTags(TagsConstants.Users)

--- a/src/Modules/Users/MentorSync.Users/Features/SearchMentors/SearchMentorsEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/SearchMentors/SearchMentorsEndpoint.cs
@@ -23,7 +23,8 @@ public sealed class SearchMentorsEndpoint : IEndpoint
 			[FromQuery] double? maxRating,
 			[FromQuery] int pageNumber,
 			[FromQuery] int pageSize,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 			{
 				var industryEnum = industry.HasValue ? (Industry?)industry.Value : null;
 				var programmingLanguagesList = programmingLanguages?.ToList();
@@ -36,13 +37,13 @@ public sealed class SearchMentorsEndpoint : IEndpoint
 					minRating,
 					maxRating,
 					pageNumber,
-					pageSize));
+					pageSize), cancellationToken);
 
 				return result.DecideWhatToReturn();
 			})
 			.WithTags(TagsConstants.Users)
 			.WithDescription("Search mentors with filters")
 			.Produces<List<MentorSearchResponse>>(StatusCodes.Status200OK)
-			.AllowAnonymous();
+			.RequireAuthorization(PolicyConstants.AdminMenteeMix);
 	}
 }

--- a/src/Modules/Users/MentorSync.Users/Features/ToggleActiveStatus/ToggleActiveUserEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/ToggleActiveStatus/ToggleActiveUserEndpoint.cs
@@ -11,9 +11,12 @@ public sealed class ToggleActiveUserEndpoint : IEndpoint
 {
 	public void MapEndpoint(IEndpointRouteBuilder app)
 	{
-		app.MapPost("/users/{userId:int}/active", async (int userId, IMediator mediator) =>
+		app.MapPost("/users/{userId:int}/active", async (
+				int userId,
+				IMediator mediator,
+				CancellationToken cancellationToken) =>
 		{
-			var result = await mediator.SendCommandAsync<ToggleActiveUserCommand, string>(new ToggleActiveUserCommand(userId));
+			var result = await mediator.SendCommandAsync<ToggleActiveUserCommand, string>(new (userId), cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Users/MentorSync.Users/Features/UploadAvatar/UploadAvatarEndpoint.cs
+++ b/src/Modules/Users/MentorSync.Users/Features/UploadAvatar/UploadAvatarEndpoint.cs
@@ -14,9 +14,10 @@ public sealed class UploadAvatarEndpoint : IEndpoint
 		app.MapPost("/users/{id:int}/avatar", async (
 			int id,
 			IFormFile file,
-			IMediator mediator) =>
+			IMediator mediator,
+			CancellationToken cancellationToken) =>
 		{
-			var result = await mediator.SendCommandAsync<UploadAvatarCommand, string>(new UploadAvatarCommand(id, file));
+			var result = await mediator.SendCommandAsync<UploadAvatarCommand, string>(new UploadAvatarCommand(id, file), cancellationToken);
 
 			return result.DecideWhatToReturn();
 		})

--- a/src/Modules/Users/MentorSync.Users/ModuleRegistration.cs
+++ b/src/Modules/Users/MentorSync.Users/ModuleRegistration.cs
@@ -119,7 +119,7 @@ public static class ModuleRegistration
 					ValidIssuer = jwtOptions.Issuer,
 					ValidAudience = jwtOptions.Audience,
 					IssuerSigningKey = new SymmetricSecurityKey(
-						Encoding.UTF8.GetBytes(jwtOptions.SecretKey))
+						Encoding.UTF8.GetBytes(jwtOptions.SecretKey)),
 				};
 
 				options.Events = new JwtBearerEvents
@@ -143,7 +143,7 @@ public static class ModuleRegistration
 						else
 						{
 							// Extract token from Authorization header (Bearer token)
-							var token = authorization.Replace("Bearer ", string.Empty);
+							var token = authorization.Replace("Bearer ", string.Empty, StringComparison.Ordinal);
 							if (!string.IsNullOrEmpty(token))
 							{
 								context.Token = token;
@@ -154,13 +154,6 @@ public static class ModuleRegistration
 					},
 				};
 			});
-
-		// TODO: implement google authentication on frontend
-		// .AddGoogle(options =>
-		// {
-		//     options.ClientId = configuration["Authentication:Google:ClientId"]!;
-		//     options.ClientSecret = configuration["Authentication:Google:ClientSecret"]!;
-		// });
 
 		services.AddScoped<IJwtTokenService, JwtTokenService>();
 


### PR DESCRIPTION
Added CancellationToken parameters to most API endpoints and mediator calls for improved request cancellation and async handling. Refactored EnumFormatter to use a mapping array for industry categories, and updated ProgrammingLanguages.Values to IReadOnlyList. Updated endpoint routes for stricter parameter types and improved consistency. Minor bug fixes and code cleanup across modules.
Refers to #107 