### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ui-build-and-test.yml
+++ b/.github/workflows/ui-build-and-test.yml
@@ -1,4 +1,6 @@
 name: UI - build & test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/AndriyBorkovich/mentor-sync/security/code-scanning/1](https://github.com/AndriyBorkovich/mentor-sync/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block to the workflow. The recommended fix is to set it at the top level of the workflow file (just after the `name:` section and before the `on:` section), ensuring all jobs inherit minimal permissions unless overridden. For a build and test job like this, the least privilege required is typically `contents: read`. This fix does not change any functionality, it simply restricts the permissions granted to the GitHub Actions `GITHUB_TOKEN`, adhering to security best practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
