### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-build-and-test.yml
+++ b/.github/workflows/backend-build-and-test.yml
@@ -1,4 +1,6 @@
 name: Backend - build & test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/AndriyBorkovich/mentor-sync/security/code-scanning/2](https://github.com/AndriyBorkovich/mentor-sync/security/code-scanning/2)

To address the flagged issue, add a `permissions` key set to the minimum necessary privileges. In this scenario, since the workflow only performs build and test jobs (no repository writes), setting `permissions: contents: read` is appropriate. This can be placed at the workflow root (applies to all jobs) or at the job level (within the `build` job). Placing it at the root is preferable if all jobs share the same requirements, and is the simplest approach. This requires adding a `permissions` block immediately after the `name:` (line 1) and before the `on:` (line 3) in `.github/workflows/backend-build-and-test.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
